### PR TITLE
Verify if Crowdsec ui is already registered before a new registration

### DIFF
--- a/roles/crowdsec/tasks/setup_web_ui.yml
+++ b/roles/crowdsec/tasks/setup_web_ui.yml
@@ -16,6 +16,16 @@
   tags:
     - "helm_chart"
 
+- name: "List CrowdSec LAPI machines"
+  kubernetes.core.k8s_exec:
+    namespace: "{{ crowdsec_namespace }}"
+    pod: "{{ crowdsec_lapi_pod_lookup.resources[0].metadata.name }}"
+    command: "cscli machines list -o json"
+  register: "crowdsec_machines_list"
+  changed_when: false
+  tags:
+    - "helm_chart"
+
 - name: "Register CrowdSec Web UI machine in LAPI"
   kubernetes.core.k8s_exec:
     namespace: "{{ crowdsec_namespace }}"
@@ -25,7 +35,13 @@
       --password {{ crowdsec_web_ui_lapi_password }}
       --file /dev/null
       --force
-  changed_when: false
+  changed_when: true
+  when:
+    - "not ansible_check_mode"
+    - >-
+      (crowdsec_machines_list.stdout | ansible.builtin.from_json
+       | selectattr('machineId', 'equalto', crowdsec_web_ui_lapi_username)
+       | list | length) == 0
   tags:
     - "helm_chart"
 


### PR DESCRIPTION
## Proposed changes
To ensure idempotence and avoid multi registration, verify if Crowdsec ui is already registered before a new registration

## Types of changes

What types of changes does your code introduce ?

- [X] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

What part of the collection has been modified ?
- [X] Roles (add a role or upgrade an existing one)
- [ ] Plugins (add a plugin or upgrade an existing one)
- [ ] Playbooks (add a playbook or upgrade an existing one)
- [ ] Tooling (no change made on the collection itself)

## Checklist

- [X] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
