### PR TITLE
Rename trust manager helm chart ref var to version

### DIFF
--- a/roles/cert_manager/README.md
+++ b/roles/cert_manager/README.md
@@ -25,7 +25,8 @@ Install cert-manager
   - [cert_manager_self_signed_enabled](#cert_manager_self_signed_enabled)
   - [cert_manager_trust_manager_deployment_name](#cert_manager_trust_manager_deployment_name)
   - [cert_manager_trust_manager_enabled](#cert_manager_trust_manager_enabled)
-  - [cert_manager_trust_manager_helm_chart_ref](#cert_manager_trust_manager_helm_chart_ref)
+  - [cert_manager_trust_manager_helm_chart_version](#cert_manager_trust_manager_helm_chart_version)
+- [Discovered Tags](#discovered-tags)
 - [Open Tasks](#open-tasks)
 - [Dependencies](#dependencies)
 - [License](#license)
@@ -265,7 +266,7 @@ Should cert-manager trust manager helm chart be installed
 cert_manager_trust_manager_enabled: false
 ```
 
-### cert_manager_trust_manager_helm_chart_ref
+### cert_manager_trust_manager_helm_chart_version
 
 Trust manager Helm chart version to install
 
@@ -274,8 +275,24 @@ Trust manager Helm chart version to install
 #### Default value
 
 ```YAML
-cert_manager_trust_manager_helm_chart_ref: jetstack/cert-manager-trust
+cert_manager_trust_manager_helm_chart_version: 0.16.0
 ```
+
+## Discovered Tags
+
+**_cert_manager_**
+
+**_helm_chart_**
+
+**_helm_repository_**
+
+**_install_**
+
+**_manifest_**
+
+**_namespace_**
+
+**_uninstall_**
 
 ## Open Tasks
 

--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -29,11 +29,11 @@ cert_manager_deployment_name: "cert-manager"
 # Should cert-manager trust manager helm chart be installed
 cert_manager_trust_manager_enabled: false
 
-# @var cert_manager_trust_manager_helm_chart_ref
-# @var cert_manager_trust_manager_helm_chart_ref:type: string
-# @var cert_manager_trust_manager_helm_chart_ref:description: >
+# @var cert_manager_trust_manager_helm_chart_version
+# @var cert_manager_trust_manager_helm_chart_version:type: string
+# @var cert_manager_trust_manager_helm_chart_version:description: >
 # Trust manager Helm chart version to install
-cert_manager_trust_manager_helm_chart_ref: "0.16.0"
+cert_manager_trust_manager_helm_chart_version: "0.16.0"
 
 # @var cert_manager_trust_manager_deployment_name
 # @var cert_manager_trust_manager_deployment_name:type: string


### PR DESCRIPTION
## Proposed changes

Rename the trust manager chart version variable in the `cert_manager` role to
fix a latent bug and a misleading name.

`roles/cert_manager/defaults/main.yml` defined
`cert_manager_trust_manager_helm_chart_ref: "0.16.0"`, but
`tasks/setup.yml` already consumes the version through
`chart_version: "{{ cert_manager_trust_manager_helm_chart_version }}"` — a
variable that was never defined. On top of that, the name collided with
`vars/main.yml`, where `cert_manager_trust_manager_helm_chart_ref` legitimately
holds the chart **path** (`jetstack/cert-manager-trust`); since `vars/` wins over
`defaults/`, the `"0.16.0"` value was dead.

This PR renames the defaults variable to
`cert_manager_trust_manager_helm_chart_version`, so:

- the trust manager chart version (`0.16.0`) is actually applied when
  `cert_manager_trust_manager_enabled: true`;
- the two concerns are cleanly separated — `_helm_chart_ref` (chart path,
  `vars/`) vs `_helm_chart_version` (version, `defaults/`).

The role README was regenerated with `ansible-doctor`.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] Documentation Update


What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)

## Checklist

- [x] Lint and unit tests pass locally with my changes (`task lint` — 0 failures)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] I have added the necessary documentation (if appropriate)
- [ ] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

The trust manager install task (`setup.yml`) is gated by
`cert_manager_trust_manager_enabled` (default `false`), which is why the
undefined variable went unnoticed: the bug only surfaces when trust manager is
enabled. No behavioural change for users who keep it disabled.
