### PR TITLE
Hide LAPI password from logs in web UI machine registr…

### DIFF
--- a/roles/crowdsec/tasks/setup_web_ui.yml
+++ b/roles/crowdsec/tasks/setup_web_ui.yml
@@ -69,6 +69,7 @@
       --force
   register: "crowdsec_web_ui_register_result"
   changed_when: true
+  no_log: true
   when:
     - "not ansible_check_mode"
     - "crowdsec_web_ui_machine_missing or crowdsec_web_ui_password_changed"


### PR DESCRIPTION
## Proposed changes

Prevent the CrowdSec LAPI password from leaking into logs during Web UI machine
registration.

In `roles/crowdsec/tasks/setup_web_ui.yml`, the task *"Register CrowdSec Web UI
machine in LAPI"* runs:

```
cscli machines add {{ crowdsec_web_ui_lapi_username }} --password {{ crowdsec_web_ui_lapi_password }} --file /dev/null --force
```

The password is passed in clear text on the command line. Without `no_log`,
Ansible exposes it in the task output and in the registered
`crowdsec_web_ui_register_result`. This PR adds `no_log: true` to the task,
consistent with the surrounding password-handling tasks (e.g. the
`set_fact` that hashes the password already uses `no_log: true`).

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)

## Checklist

- [x] Lint and unit tests pass locally with my changes (`task lint` — 0 failures)
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [ ] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

Pure security hardening — no functional change. The registered result is only
used for control flow (`changed_when: true`), so hiding its content has no
side effect on the play.
