### PR TITLE
Add crds_keep option and migrate to crds.enabled

### DIFF
--- a/roles/cert_manager/README.md
+++ b/roles/cert_manager/README.md
@@ -18,6 +18,7 @@ Install cert-manager
   - [cert_manager_acme_staging_private_key_ref](#cert_manager_acme_staging_private_key_ref)
   - [cert_manager_acme_staging_solver](#cert_manager_acme_staging_solver)
   - [cert_manager_acme_staging_url](#cert_manager_acme_staging_url)
+  - [cert_manager_crds_keep](#cert_manager_crds_keep)
   - [cert_manager_deployment_name](#cert_manager_deployment_name)
   - [cert_manager_enabled](#cert_manager_enabled)
   - [cert_manager_helm_chart_version](#cert_manager_helm_chart_version)
@@ -180,6 +181,20 @@ cert_manager_acme_staging_solver:
 
 ```YAML
 cert_manager_acme_staging_url: https://acme-staging-v02.api.letsencrypt.org/directory
+```
+
+### cert_manager_crds_keep
+
+Keep the cert-manager CRDs when the chart is uninstalled (prevents accidental
+deletion of Certificate/Issuer custom resources). Applies to both the
+cert-manager and trust-manager charts.
+
+**_Type:_** boolean<br />
+
+#### Default value
+
+```YAML
+cert_manager_crds_keep: true
 ```
 
 ### cert_manager_deployment_name

--- a/roles/cert_manager/defaults/main.yml
+++ b/roles/cert_manager/defaults/main.yml
@@ -17,6 +17,14 @@ cert_manager_namespace: "cert-manager"
 # Helm chart version to install
 cert_manager_helm_chart_version: 1.21.0
 
+# @var cert_manager_crds_keep
+# @var cert_manager_crds_keep:type: boolean
+# @var cert_manager_crds_keep:description: >
+# Keep the cert-manager CRDs when the chart is uninstalled (prevents accidental
+# deletion of Certificate/Issuer custom resources). Applies to both the
+# cert-manager and trust-manager charts.
+cert_manager_crds_keep: true
+
 # @var cert_manager_deployment_name
 # @var cert_manager_deployment_name:type: string
 # @var cert_manager_deployment_name:description: >

--- a/roles/cert_manager/tasks/setup.yml
+++ b/roles/cert_manager/tasks/setup.yml
@@ -24,7 +24,9 @@
     chart_version: "{{ cert_manager_helm_chart_version }}"
     update_repo_cache: true
     values:
-      installCRDs: true
+      crds:
+        enabled: true
+        keep: "{{ cert_manager_crds_keep | bool }}"
     wait: true
   tags:
     - "helm_chart"
@@ -37,7 +39,9 @@
     chart_version: "{{ cert_manager_trust_manager_helm_chart_version }}"
     update_repo_cache: true
     values:
-      installCRDs: true
+      crds:
+        enabled: true
+        keep: "{{ cert_manager_crds_keep | bool }}"
     wait: true
   when: cert_manager_trust_manager_enabled
   tags:


### PR DESCRIPTION
## Proposed changes

Replace the deprecated `installCRDs` Helm value with the `crds.enabled` / `crds.keep` block for both the cert-manager and trust-manager charts.

Introduce the `cert_manager_crds_keep` variable (default true) to keep the CRDs on chart uninstall, preventing accidental deletion of Certificate and Issuer custom resources.

## Types of changes

What types of changes does your code introduce ?
- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

Fixes # (issue)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)
- [ ] Plugins (add a plugin or upgrade an existing one)
- [ ] Playbooks (add a playbook or upgrade an existing one)
- [ ] Tooling (no change made on the collection itself)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
