### PR TITLE
feature(traefik): Add plugins abort on failure

### DIFF
--- a/roles/traefik/README.md
+++ b/roles/traefik/README.md
@@ -81,6 +81,7 @@ traefik_deployments:
       dashboard_enabled: false
       access_logs: {}
       plugins: []
+      plugins_abort_on_failure: false
       service_annotations: {}
       service_labels: {}
       service_spec: {}
@@ -142,6 +143,7 @@ traefik_deployments:
          - name: "bouncer"
            moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
            version: "v1.4.3"
+       plugins_abort_on_failure: true
        service_annotations:
          service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
        service_labels: {}

--- a/roles/traefik/defaults/main.yml
+++ b/roles/traefik/defaults/main.yml
@@ -109,6 +109,7 @@ traefik_gateway_api_channel: "standard"
 #          - name: "bouncer"
 #            moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
 #            version: "v1.4.3"
+#        plugins_abort_on_failure: true
 #        service_annotations:
 #          service.beta.kubernetes.io/ovh-loadbalancer-proxy-protocol: "v2"
 #        service_labels: {}
@@ -152,6 +153,7 @@ traefik_deployments:
       dashboard_enabled: false
       access_logs: {}
       plugins: []
+      plugins_abort_on_failure: false
       service_annotations: {}
       service_labels: {}
       service_spec: {}

--- a/roles/traefik/molecule/default/converge.yml
+++ b/roles/traefik/molecule/default/converge.yml
@@ -41,6 +41,7 @@
             - name: "bouncer"
               moduleName: "github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin"
               version: "v1.4.3"
+          plugins_abort_on_failure: true
           additional_values:
             commonLabels:
               traefik-test-propagation: "enabled"

--- a/roles/traefik/molecule/default/verify.yml
+++ b/roles/traefik/molecule/default/verify.yml
@@ -134,6 +134,7 @@
         that:
           - release_values['experimental']['plugins']['bouncer']['moduleName']
             == 'github.com/maxlerebourg/crowdsec-bouncer-traefik-plugin'
+          - release_values['experimental']['abortOnPluginFailure'] | bool
           - release_values['accessLog']['enabled'] | bool
           - release_values['accessLog']['format'] == 'json'
           - release_values['commonLabels']['traefik-test-propagation'] == 'enabled'

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -2,11 +2,23 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "traefik"
+        - "install"
   when: traefik_ingress_enabled
-  tags: ["always"]
+  tags:
+    - "traefik"
+    - "install"
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "traefik"
+        - "uninstall"
   when: not traefik_ingress_enabled
-  tags: ["always"]
+  tags:
+    - "traefik"
+    - "uninstall"

--- a/roles/traefik/tasks/setup.yml
+++ b/roles/traefik/tasks/setup.yml
@@ -34,12 +34,12 @@
     - "traefik_crds_upgrade_enabled"
     - "traefik_current_release.status.chart is defined"
     - "traefik_current_release.item.state | default('present') == 'present'"
-  tags: ["always"]
 
 - name: "Install Kubernetes Gateway API CRDs"
   ansible.builtin.include_tasks: "install_gateway_api_crds.yml"
   when: "traefik_gateway_api_crds_install"
-  tags: ["always"]
+  tags:
+    - "crds"
 
 - name: "Instanciate ip addresses list"
   ansible.builtin.set_fact:
@@ -50,7 +50,8 @@
   loop: "{{ traefik_deployments }}"
   loop_control:
     loop_var: "traefik_current_instance"
-  tags: ["always"]
+  tags:
+    - "helm_chart"
 
 - name: "Create middlewares"
   kubernetes.core.k8s:

--- a/roles/traefik/templates/traefik_helm_values.yml.j2
+++ b/roles/traefik/templates/traefik_helm_values.yml.j2
@@ -136,14 +136,17 @@ accessLog:
 {% endif %}
 {% endif %}
 
-{% if plugins | default([]) | length > 0 %}
+{% if (plugins | default([]) | length > 0) or (plugins_abort_on_failure | default(false)) %}
 experimental:
+  abortOnPluginFailure: {{ plugins_abort_on_failure | default(false) }}
+{% if plugins | default([]) | length > 0 %}
   plugins:
 {% for plugin in plugins %}
     {{ plugin.name }}:
       moduleName: "{{ plugin.moduleName }}"
       version: "{{ plugin.version }}"
 {% endfor %}
+{% endif %}
 {% endif %}
 
 {% if additional_values | default({}) != {} %}


### PR DESCRIPTION
## Proposed changes

Traefik fail to start if plugins can't be downloaded 

## Types of changes

What types of changes does your code introduce ?
- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)
- [ ] Plugins (add a plugin or upgrade an existing one)
- [ ] Playbooks (add a playbook or upgrade an existing one)
- [ ] Tooling (no change made on the collection itself)

## Checklist
- [x] Lint and unit tests pass locally with my changes
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [x] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
