### PR TITLE
Propagate role/phase tags through dynamic include_tasks

### DIFF
--- a/roles/cert_manager/tasks/main.yml
+++ b/roles/cert_manager/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "cert_manager"
+        - "install"
   when: cert_manager_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "cert_manager"
+        - "uninstall"
   when: not cert_manager_enabled
   tags: ["always"]

--- a/roles/crowdsec/tasks/main.yml
+++ b/roles/crowdsec/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "crowdsec"
+        - "install"
   when: crowdsec_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "crowdsec"
+        - "uninstall"
   when: not crowdsec_enabled
   tags: ["always"]

--- a/roles/external_dns/tasks/main.yml
+++ b/roles/external_dns/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "external_dns"
+        - "install"
   when: external_dns_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "external_dns"
+        - "uninstall"
   when: not external_dns_enabled
   tags: ["always"]

--- a/roles/metallb/tasks/main.yml
+++ b/roles/metallb/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "metallb"
+        - "install"
   when: metallb_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "metallb"
+        - "uninstall"
   when: not metallb_enabled
   tags: ["always"]

--- a/roles/mongodb/tasks/main.yml
+++ b/roles/mongodb/tasks/main.yml
@@ -50,6 +50,10 @@
 - name: "Call updating mongodb instance task"
   ansible.builtin.include_tasks:
     file: "update_instance_values.yml"
+    apply:
+      tags:
+        - "mongodb"
+        - "install"
   loop: "{{ mongodb_instance_values_override | ansible.builtin.dict2items }}"
   loop_control:
     loop_var: "value_to_update"

--- a/roles/rancher/tasks/main.yml
+++ b/roles/rancher/tasks/main.yml
@@ -2,11 +2,19 @@
 - name: "Include setup when enabled"
   ansible.builtin.include_tasks:
     file: "setup.yml"
+    apply:
+      tags:
+        - "rancher"
+        - "install"
   when: rancher_enabled
   tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
     file: "cleanup.yml"
+    apply:
+      tags:
+        - "rancher"
+        - "uninstall"
   when: not rancher_enabled
   tags: ["always"]

--- a/roles/traefik/tasks/main.yml
+++ b/roles/traefik/tasks/main.yml
@@ -7,9 +7,7 @@
         - "traefik"
         - "install"
   when: traefik_ingress_enabled
-  tags:
-    - "traefik"
-    - "install"
+  tags: ["always"]
 
 - name: "Include cleanup when disabled"
   ansible.builtin.include_tasks:
@@ -19,6 +17,4 @@
         - "traefik"
         - "uninstall"
   when: not traefik_ingress_enabled
-  tags:
-    - "traefik"
-    - "uninstall"
+  tags: ["always"]


### PR DESCRIPTION
## Proposed changes

Dynamic `include_tasks` do not propagate their tags to the included tasks, so
running with `--tags <role>` matched the include but **silently skipped** every
task inside `setup.yml` / `cleanup.yml` (role reported `ok=2 changed=0` while
doing nothing). Full plays were never affected.

## Types of changes

- [x] Bugfix (non-breaking change which fixes an issue)

Fixes # (issue)

What part of the collection has been modified ?
- [x] Roles (add a role or upgrade an existing one)

## Checklist

- [x] Lint and unit tests pass locally with my changes
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] I have added the necessary documentation (if appropriate)
- [X] I have labeled this PR
- [ ] Any dependent changes have been merged and published in downstream modules
